### PR TITLE
add the ability to set a java home path explicitly in the build

### DIFF
--- a/gradle-keytool-plugin/README.md
+++ b/gradle-keytool-plugin/README.md
@@ -2,7 +2,11 @@
 
 # Requirements
 
-In order to run the Keytool plugin you must ensure your JAVA_HOME environment variable is set to a JDK location.
+In order to run the Keytool plugin you must ensure your JAVA_HOME environment variable is set to a JDK location, or you must specify a javaHome like so:
+
+    keytool {
+        javaHome = '/path/to/my/jdk/'
+    }
 
 # Common Keytool Commands:
 

--- a/gradle-keytool-plugin/src/main/groovy/org/figurate/gradle/plugin/keytool/KeytoolExt.groovy
+++ b/gradle-keytool-plugin/src/main/groovy/org/figurate/gradle/plugin/keytool/KeytoolExt.groovy
@@ -1,0 +1,8 @@
+package org.figurate.gradle.plugin.keytool
+
+class KeytoolExt {
+    
+    String javaHome
+	
+}
+

--- a/gradle-keytool-plugin/src/main/groovy/org/figurate/gradle/plugin/keytool/KeytoolPlugin.groovy
+++ b/gradle-keytool-plugin/src/main/groovy/org/figurate/gradle/plugin/keytool/KeytoolPlugin.groovy
@@ -10,6 +10,7 @@ class KeytoolPlugin implements Plugin<Project> {
 
     @Override
     void apply(Project project) {
+        project.extensions.add('keytool', new KeytoolExt())
         project.buildDir.mkdirs()
         project.task('keytool', type: KeytoolTask)
 

--- a/gradle-keytool-plugin/src/main/groovy/org/figurate/gradle/plugin/keytool/KeytoolTask.groovy
+++ b/gradle-keytool-plugin/src/main/groovy/org/figurate/gradle/plugin/keytool/KeytoolTask.groovy
@@ -10,7 +10,8 @@ import java.security.KeyStore
 class KeytoolTask extends Exec {
 
     KeytoolTask() {
-        executable "${new File((String) environment['JAVA_HOME'], 'bin').canonicalPath}/keytool"
+        def javaHome = project.keytool.javaHome ? project.keytool.javaHome : environment['JAVA_HOME']
+        executable "${new File((String) javaHome, 'bin').canonicalPath}/keytool"
         extensions.add('options', new KeytoolArgsExtension())
     }
 

--- a/gradle-keytool-plugin/src/test/groovy/org/figurate/gradle/plugin/keytool/KeytoolTaskSpec.groovy
+++ b/gradle-keytool-plugin/src/test/groovy/org/figurate/gradle/plugin/keytool/KeytoolTaskSpec.groovy
@@ -12,6 +12,33 @@ class KeytoolTaskSpec extends Specification {
     def 'test list certs'() {
         given:
         Project project = ProjectBuilder.builder().build()
+        project.extensions.add('keytool', new KeytoolExt())
+        project.task('keytool', type: KeytoolTask)
+
+        and:
+        project.tasks.keytool {
+            args '-list'
+            options {
+                keystore = "${System.getenv()['JAVA_HOME']}/jre/lib/security/cacerts"
+                storepass = 'changeit'
+            }
+        }
+
+        and: 'capture output'
+        project.tasks.keytool.standardOutput = new ByteArrayOutputStream()
+
+        when:
+        project.tasks.keytool.execute()
+
+        then:
+        project.tasks.keytool.standardOutput.toString().startsWith('\nKeystore type: ')
+    }
+    
+    def 'setting keytool.javaHome works'() {
+        given:
+        Project project = ProjectBuilder.builder().build()
+        project.extensions.add('keytool', new KeytoolExt())
+        project.keytool.javaHome = "${System.getenv()['JAVA_HOME']}"
         project.task('keytool', type: KeytoolTask)
 
         and:


### PR DESCRIPTION
Some CI environments that support builds for a wide variety of projects maintain multiple java installations (usually for different jdk versions). In such environments, using the JAVA_HOME environment variable to locate the proper keytool executable won't work. This provides an optional alternative way to specify the the java home through a project extension, i.e.

keytool {
    javaHome = '/my/java/home'
}